### PR TITLE
Upload policy

### DIFF
--- a/imagekit/src/main/AndroidManifest.xml
+++ b/imagekit/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="com.imagekit.android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/imagekit/src/main/java/com/imagekit/android/ImageKit.kt
+++ b/imagekit/src/main/java/com/imagekit/android/ImageKit.kt
@@ -18,7 +18,8 @@ class ImageKit private constructor(
     clientPublicKey: String,
     imageKitEndpoint: String,
     transformationPosition: TransformationPosition,
-    authenticationEndpoint: String
+    authenticationEndpoint: String,
+    val defaultUploadPolicy: UploadPolicy
 ) {
 
     @Inject
@@ -56,7 +57,8 @@ class ImageKit private constructor(
             publicKey: String = "",
             urlEndpoint: String,
             transformationPosition: TransformationPosition = TransformationPosition.PATH,
-            authenticationEndpoint: String = ""
+            authenticationEndpoint: String = "",
+            defaultUploadPolicy: UploadPolicy = UploadPolicy.defaultPolicy()
         ) {
             if (context !is Application)
                 throw Exception("Application Context Expected!!")
@@ -67,7 +69,8 @@ class ImageKit private constructor(
                 publicKey,
                 urlEndpoint,
                 transformationPosition,
-                authenticationEndpoint
+                authenticationEndpoint,
+                defaultUploadPolicy
             )
         }
 

--- a/imagekit/src/main/java/com/imagekit/android/ImageKit.kt
+++ b/imagekit/src/main/java/com/imagekit/android/ImageKit.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
 import com.imagekit.android.entity.TransformationPosition
+import com.imagekit.android.entity.UploadPolicy
 import com.imagekit.android.injection.component.DaggerUtilComponent
 import com.imagekit.android.injection.component.UtilComponent
 import com.imagekit.android.injection.module.ContextModule

--- a/imagekit/src/main/java/com/imagekit/android/ImagekitUploader.kt
+++ b/imagekit/src/main/java/com/imagekit/android/ImagekitUploader.kt
@@ -44,6 +44,7 @@ class ImagekitUploader @Inject constructor(
         folder: String? = null,
         isPrivateFile: Boolean = false,
         customCoordinates: String? = null,
+        uploadPolicy: UploadPolicy = ImageKit.getInstance().defaultUploadPolicy,
         responseFields: String? = null,
         imageKitCallback: ImageKitCallback
     ) {
@@ -60,6 +61,7 @@ class ImagekitUploader @Inject constructor(
             isPrivateFile,
             customCoordinates,
             responseFields,
+            uploadPolicy,
             imageKitCallback
         )
     }
@@ -96,6 +98,7 @@ class ImagekitUploader @Inject constructor(
         isPrivateFile: Boolean = false,
         customCoordinates: String? = null,
         responseFields: String? = null,
+        uploadPolicy: UploadPolicy = ImageKit.getInstance().defaultUploadPolicy,
         imageKitCallback: ImageKitCallback
     ) {
         if (!file.exists()) {
@@ -116,6 +119,7 @@ class ImagekitUploader @Inject constructor(
             isPrivateFile,
             customCoordinates,
             responseFields,
+            uploadPolicy,
             imageKitCallback
         )
     }
@@ -152,6 +156,7 @@ class ImagekitUploader @Inject constructor(
         isPrivateFile: Boolean = false,
         customCoordinates: String? = null,
         responseFields: String? = null,
+        uploadPolicy: UploadPolicy,
         imageKitCallback: ImageKitCallback
     ) = mRepository.upload(
         file,
@@ -162,6 +167,7 @@ class ImagekitUploader @Inject constructor(
         isPrivateFile,
         customCoordinates,
         responseFields,
+        uploadPolicy,
         imageKitCallback
     )
 }

--- a/imagekit/src/main/java/com/imagekit/android/ImagekitUploader.kt
+++ b/imagekit/src/main/java/com/imagekit/android/ImagekitUploader.kt
@@ -39,6 +39,8 @@ class ImagekitUploader @Inject constructor(
      * and width and height of the area of interest in format x,y,width,height. For example - 10,10,100,100.
      * Can be used with fo-custom transformation.
      * If this field is not specified and the file is overwritten, then customCoordinates will be removed.
+     * @param policy Set the custom policy to override the default policy for this upload request only.
+     * This doesn't modify the default upload policy.
      * @param responseFields Comma-separated values of the fields that you want ImageKit.io to return in response.
      * For example, set the value of this field to tags,customCoordinates,isPrivateFile,metadata to get value of tags,
      * customCoordinates, isPrivateFile , and metadata in the response.
@@ -52,11 +54,11 @@ class ImagekitUploader @Inject constructor(
         folder: String? = null,
         isPrivateFile: Boolean = false,
         customCoordinates: String? = null,
-        uploadPolicy: UploadPolicy = ImageKit.getInstance().defaultUploadPolicy,
+        policy: UploadPolicy = ImageKit.getInstance().defaultUploadPolicy,
         responseFields: String? = null,
         imageKitCallback: ImageKitCallback
     ) {
-        if (checkUploadPolicy(uploadPolicy,imageKitCallback)) {
+        if (checkUploadPolicy(policy, imageKitCallback)) {
             mRepository.upload(
                 bitmapToFile(
                     context,
@@ -70,7 +72,7 @@ class ImagekitUploader @Inject constructor(
                 isPrivateFile,
                 customCoordinates,
                 responseFields,
-                uploadPolicy,
+                policy,
                 imageKitCallback
             )
         } else {
@@ -96,6 +98,8 @@ class ImagekitUploader @Inject constructor(
      * and width and height of the area of interest in format x,y,width,height. For example - 10,10,100,100.
      * Can be used with fo-custom transformation.
      * If this field is not specified and the file is overwritten, then customCoordinates will be removed.
+     * @param policy Set the custom policy to override the default policy for this upload request only.
+     * This doesn't modify the default upload policy.
      * @param responseFields Comma-separated values of the fields that you want ImageKit.io to return in response.
      * For example, set the value of this field to tags,customCoordinates,isPrivateFile,metadata to get value of tags,
      * customCoordinates, isPrivateFile , and metadata in the response.
@@ -110,10 +114,10 @@ class ImagekitUploader @Inject constructor(
         isPrivateFile: Boolean = false,
         customCoordinates: String? = null,
         responseFields: String? = null,
-        uploadPolicy: UploadPolicy = ImageKit.getInstance().defaultUploadPolicy,
+        policy: UploadPolicy = ImageKit.getInstance().defaultUploadPolicy,
         imageKitCallback: ImageKitCallback
     ) {
-        if (checkUploadPolicy(uploadPolicy, imageKitCallback)) {
+        if (checkUploadPolicy(policy, imageKitCallback)) {
             if (!file.exists()) {
                 imageKitCallback.onError(
                     UploadError(
@@ -132,7 +136,7 @@ class ImagekitUploader @Inject constructor(
                 isPrivateFile,
                 customCoordinates,
                 responseFields,
-                uploadPolicy,
+                policy,
                 imageKitCallback
             )
         } else {
@@ -158,6 +162,8 @@ class ImagekitUploader @Inject constructor(
      * and width and height of the area of interest in format x,y,width,height. For example - 10,10,100,100.
      * Can be used with fo-custom transformation.
      * If this field is not specified and the file is overwritten, then customCoordinates will be removed.
+     * @param policy Set the custom policy to override the default policy for this upload request only.
+     * This doesn't modify the default upload policy.
      * @param responseFields Comma-separated values of the fields that you want ImageKit.io to return in response.
      * For example, set the value of this field to tags,customCoordinates,isPrivateFile,metadata to get value of tags,
      * customCoordinates, isPrivateFile , and metadata in the response.
@@ -172,7 +178,7 @@ class ImagekitUploader @Inject constructor(
         isPrivateFile: Boolean = false,
         customCoordinates: String? = null,
         responseFields: String? = null,
-        uploadPolicy: UploadPolicy,
+        policy: UploadPolicy,
         imageKitCallback: ImageKitCallback
     ) = mRepository.upload(
         file,
@@ -183,7 +189,7 @@ class ImagekitUploader @Inject constructor(
         isPrivateFile,
         customCoordinates,
         responseFields,
-        uploadPolicy,
+        policy,
         imageKitCallback
     )
 
@@ -195,7 +201,8 @@ class ImagekitUploader @Inject constructor(
                 imageKitCallback.onError(
                     UploadError(
                         exception = false,
-                        statusCode = "UPLOAD_POLICY_ERROR",
+                        statusNumber = 1501,
+                        statusCode = "POLICY_ERROR_METERED_NETWORK",
                         message = "Upload policy error: current network is metered"
                     )
                 )
@@ -215,7 +222,8 @@ class ImagekitUploader @Inject constructor(
                 imageKitCallback.onError(
                     UploadError(
                         exception = false,
-                        statusCode = "UPLOAD_POLICY_ERROR",
+                        statusNumber = 1502,
+                        statusCode = "POLICY_ERROR_BATTERY_DISCHARGING",
                         message = "Upload policy error: device battery is not charging"
                     )
                 )
@@ -229,7 +237,8 @@ class ImagekitUploader @Inject constructor(
                 imageKitCallback.onError(
                     UploadError(
                         exception = false,
-                        statusCode = "UPLOAD_POLICY_ERROR",
+                        statusNumber = 1503,
+                        statusCode = "POLICY_ERROR_DEVICE_NOT_IDLE",
                         message = "Upload policy error: device is not in idle mode"
                     )
                 )

--- a/imagekit/src/main/java/com/imagekit/android/UploadPolicy.kt
+++ b/imagekit/src/main/java/com/imagekit/android/UploadPolicy.kt
@@ -1,0 +1,94 @@
+package com.imagekit.android
+
+class UploadPolicy private constructor(
+    val networkType: NetworkType,
+    val requiresCharging: Boolean,
+    val requiresIdle: Boolean,
+    val maxErrorRetries: Int,
+    val backoffMillis: Long,
+    val backoffPolicy: BackoffPolicy
+) {
+
+    enum class NetworkType {
+        ANY,
+        UNMETERED
+    }
+
+    enum class BackoffPolicy {
+        LINEAR,
+        EXPONENTIAL
+    }
+
+    class Builder {
+        private var networkType = NetworkType.ANY
+        private var requiresCharging = false
+        private var requiresIdle = false
+        private var maxRetries = DEFAULT_MAX_ERROR_RETRIES
+        private var backoffMillis = DEFAULT_BACKOFF_MILLIS
+        private var backoffPolicy = DEFAULT_BACKOFF_POLICY
+
+        fun requireNetworkType(networkPolicy: NetworkType): Builder {
+            this.networkType = networkPolicy
+            return this
+        }
+
+        fun requiresBatteryCharging(requiresCharging: Boolean): Builder {
+            this.requiresCharging = requiresCharging
+            return this
+        }
+
+        fun requiresDeviceIdle(requiresIdle: Boolean): Builder {
+            this.requiresIdle = requiresIdle
+            return this
+        }
+
+        fun maxRetries(maxRetries: Int): Builder {
+            require(maxRetries >= 0) { "maxRetries cannot be negative." }
+            this.maxRetries = maxRetries
+            return this
+        }
+
+        fun backoffCriteria(backoffMillis: Long, backoffPolicy: BackoffPolicy): Builder {
+            this.backoffMillis = backoffMillis
+            this.backoffPolicy = backoffPolicy
+            return this
+        }
+
+        fun build(): UploadPolicy {
+            return UploadPolicy(
+                networkType,
+                requiresCharging,
+                requiresIdle,
+                maxRetries,
+                backoffMillis,
+                backoffPolicy
+            )
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_MAX_ERROR_RETRIES = 5
+        private const val DEFAULT_BACKOFF_MILLIS = 100_000L
+        private val DEFAULT_BACKOFF_POLICY = BackoffPolicy.LINEAR
+
+        fun defaultPolicy(): UploadPolicy = Builder()
+            .requireNetworkType(NetworkType.ANY)
+            .requiresDeviceIdle(false)
+            .requiresBatteryCharging(false)
+            .maxRetries(DEFAULT_MAX_ERROR_RETRIES)
+            .backoffCriteria(
+                backoffMillis = UploadPolicy.DEFAULT_BACKOFF_MILLIS,
+                backoffPolicy = UploadPolicy.DEFAULT_BACKOFF_POLICY
+            )
+            .build()
+    }
+
+    fun newBuilder(): Builder {
+        return Builder()
+            .requiresBatteryCharging(requiresCharging)
+            .requiresDeviceIdle(requiresIdle)
+            .backoffCriteria(backoffMillis, backoffPolicy)
+            .maxRetries(maxErrorRetries)
+            .requireNetworkType(networkType)
+    }
+}

--- a/imagekit/src/main/java/com/imagekit/android/data/Repository.kt
+++ b/imagekit/src/main/java/com/imagekit/android/data/Repository.kt
@@ -2,13 +2,6 @@ package com.imagekit.android.data
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
-import android.database.Observable
-import android.net.ConnectivityManager
-import android.os.BatteryManager
-import android.os.Build
-import android.os.PowerManager
 import android.util.Log
 import com.google.gson.Gson
 import com.imagekit.android.ImageKitCallback
@@ -20,6 +13,7 @@ import com.imagekit.android.entity.UploadResponse
 import com.imagekit.android.retrofit.NetworkManager
 import com.imagekit.android.util.LogUtil
 import com.imagekit.android.util.SharedPrefUtil
+import io.reactivex.Single
 import retrofit2.HttpException
 import java.util.Timer
 import java.util.concurrent.TimeUnit
@@ -47,7 +41,8 @@ class Repository @Inject constructor(
         customCoordinates: String?,
         responseFields: String?,
         uploadPolicy: UploadPolicy,
-        imageKitCallback: ImageKitCallback
+        imageKitCallback: ImageKitCallback,
+        retryCount: Int = 0
     ) {
         val expire = ((System.currentTimeMillis() / 1000) + TimeUnit.MINUTES.toSeconds(
             DURATION_EXPIRY_MINUTES
@@ -76,74 +71,101 @@ class Repository @Inject constructor(
             )
         }
 
-//        var retryCount = 0
-//        while(retryCount<uploadPolicy.maxErrorRetries){
-//            Timer().schedule(getRetryTimeOut(uploadPolicy, retryCount)) {
-//                Log.d("IKUpload", "Retry ###")
-//
-//            }
-//
-//        }
-        NetworkManager.getSignature(endPoint, expire)
-            .doOnError { _ ->
-                imageKitCallback.onError(
-                    UploadError(
-                        true,
-                        message = context.getString(R.string.error_signature_generation_failed)
-                    )
-                )
-            }
-            .flatMap { signatureResponse: SignatureResponse ->
-                NetworkManager.getFileUploadCall(
-                    publicKey,
-                    signatureResponse,
-                    file,
-                    fileName,
-                    useUniqueFilename,
-                    tags,
-                    folder,
-                    isPrivateFile,
-                    customCoordinates,
-                    responseFields
-                ).doOnError { e ->
-                    if (e is HttpException) {
-                        e.response()?.let {
-                            try {
-                                imageKitCallback.onError(
-                                    Gson().fromJson(
-                                        it.errorBody()!!.string(),
-                                        UploadError::class.java
-                                    )
-                                )
-                            } catch (exception: IllegalStateException) {
-                                imageKitCallback.onError(
-                                    UploadError(
-                                        exception = true,
-                                        statusNumber = e.code(),
-                                        message = e.message()
-                                    )
-                                )
-                            }
-                        }
-                    } else {
-                        e.message?.let {
-                            imageKitCallback.onError(UploadError(true, message = it))
-                        } ?: run {
-                            imageKitCallback.onError(UploadError(true))
-                        }
+        Single.timer(getRetryTimeOut(uploadPolicy, retryCount), TimeUnit.MILLISECONDS).subscribe {_, _ ->
+            NetworkManager.getSignature(endPoint, expire)
+                .doOnError { _ ->
+                    if (retryCount==uploadPolicy.maxErrorRetries){
+                        imageKitCallback.onError(
+                            UploadError(
+                                true,
+                                message = context.getString(R.string.error_signature_generation_failed)
+                            )
+                        )
+                    }else{
+                        upload(
+                            file,
+                            fileName,
+                            useUniqueFilename,
+                            tags,
+                            folder,
+                            isPrivateFile,
+                            customCoordinates,
+                            responseFields,
+                            uploadPolicy,
+                            imageKitCallback,
+                            retryCount + 1
+                        )
                     }
                 }
-            }
-            .subscribe({ response ->
-                imageKitCallback.onSuccess(
-                    Gson().fromJson(
-                        response.string(),
-                        UploadResponse::class.java
+                .flatMap { signatureResponse: SignatureResponse ->
+                    NetworkManager.getFileUploadCall(
+                        publicKey,
+                        signatureResponse,
+                        file,
+                        fileName,
+                        useUniqueFilename,
+                        tags,
+                        folder,
+                        isPrivateFile,
+                        customCoordinates,
+                        responseFields
+                    ).doOnError { e ->
+                       if(retryCount==uploadPolicy.maxErrorRetries){
+                           if (e is HttpException) {
+                               e.response()?.let {
+                                   try {
+                                       imageKitCallback.onError(
+                                           Gson().fromJson(
+                                               it.errorBody()!!.string(),
+                                               UploadError::class.java
+                                           )
+                                       )
+                                   } catch (exception: IllegalStateException) {
+                                       imageKitCallback.onError(
+                                           UploadError(
+                                               exception = true,
+                                               statusNumber = e.code(),
+                                               message = e.message()
+                                           )
+                                       )
+                                   }
+                               }
+                           } else {
+                               e.message?.let {
+                                   imageKitCallback.onError(UploadError(true, message = it))
+                               } ?: run {
+                                   imageKitCallback.onError(UploadError(true))
+                               }
+                           }
+                       }else{
+                           upload(
+                               file,
+                               fileName,
+                               useUniqueFilename,
+                               tags,
+                               folder,
+                               isPrivateFile,
+                               customCoordinates,
+                               responseFields,
+                               uploadPolicy,
+                               imageKitCallback,
+                               retryCount + 1
+                           )
+                       }
+                    }
+                }
+                .subscribe({ response ->
+                    imageKitCallback.onSuccess(
+                        Gson().fromJson(
+                            response.string(),
+                            UploadResponse::class.java
+                        )
                     )
-                )
-            }, { e ->
-                LogUtil.logError(e)
-            })
+                }, { e ->
+                    LogUtil.logError(e)
+                })
+        }
+
 
     }
 

--- a/imagekit/src/main/java/com/imagekit/android/data/Repository.kt
+++ b/imagekit/src/main/java/com/imagekit/android/data/Repository.kt
@@ -2,11 +2,10 @@ package com.imagekit.android.data
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.util.Log
 import com.google.gson.Gson
 import com.imagekit.android.ImageKitCallback
 import com.imagekit.android.R
-import com.imagekit.android.UploadPolicy
+import com.imagekit.android.entity.UploadPolicy
 import com.imagekit.android.entity.SignatureResponse
 import com.imagekit.android.entity.UploadError
 import com.imagekit.android.entity.UploadResponse
@@ -15,10 +14,8 @@ import com.imagekit.android.util.LogUtil
 import com.imagekit.android.util.SharedPrefUtil
 import io.reactivex.Single
 import retrofit2.HttpException
-import java.util.Timer
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import kotlin.concurrent.schedule
 import kotlin.math.pow
 
 

--- a/imagekit/src/main/java/com/imagekit/android/data/Repository.kt
+++ b/imagekit/src/main/java/com/imagekit/android/data/Repository.kt
@@ -65,17 +65,6 @@ class Repository @Inject constructor(
             )
         }
 
-        if (!checkUploadPolicy(uploadPolicy)) {
-            LogUtil.logError("Upload failed! Upload Policy Violation!")
-            return imageKitCallback.onError(
-                UploadError(
-                    exception = true,
-                    message = "Upload failed! Upload Policy Violation!"
-                )
-            )
-        }
-
-
         val publicKey = sharedPrefUtil.getClientPublicKey()
         if (publicKey.isBlank()) {
             LogUtil.logError("Upload failed! Public Key is missing!")
@@ -156,41 +145,6 @@ class Repository @Inject constructor(
                 LogUtil.logError(e)
             })
 
-    }
-
-    private fun checkUploadPolicy(policy: UploadPolicy): Boolean {
-        if (policy.networkType == UploadPolicy.NetworkType.UNMETERED) {
-            val service =
-                context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            Log.d("Network Type", "" + service.isActiveNetworkMetered)
-            if (service.isActiveNetworkMetered) {
-                return false
-            }
-        }
-
-        if (policy.requiresCharging) {
-            val batteryStatus: Intent? =
-                IntentFilter(Intent.ACTION_BATTERY_CHANGED).let { ifilter ->
-                    context.registerReceiver(null, ifilter)
-                }
-            val status: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
-            val isCharging: Boolean = status == BatteryManager.BATTERY_STATUS_CHARGING
-                    || status == BatteryManager.BATTERY_STATUS_FULL
-            Log.d("Charging", isCharging.toString())
-            if (!isCharging) {
-                return false
-            }
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && policy.requiresIdle) {
-            val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
-            Log.d("Device State", powerManager.toString())
-            if (!powerManager.isDeviceIdleMode) {
-                return false
-            }
-        }
-
-        return true
     }
 
     private fun getRetryTimeOut(policy: UploadPolicy, retryCount: Int): Long {

--- a/imagekit/src/main/java/com/imagekit/android/data/Repository.kt
+++ b/imagekit/src/main/java/com/imagekit/android/data/Repository.kt
@@ -166,15 +166,10 @@ class Repository @Inject constructor(
 
     }
 
-    private fun getRetryTimeOut(policy: UploadPolicy, retryCount: Int): Long {
-        var retryTimeOut = policy.backoffMillis
-        if (policy.backoffPolicy == UploadPolicy.BackoffPolicy.LINEAR) {
-            retryTimeOut *= retryCount
-        }
-        if (policy.backoffPolicy == UploadPolicy.BackoffPolicy.EXPONENTIAL) {
-            retryTimeOut *= 2.0.pow(retryCount.toDouble()).toLong()
-        }
-        return retryTimeOut
-    }
-
+    private fun getRetryTimeOut(policy: UploadPolicy, retryCount: Int): Long =
+        if (policy.backoffPolicy == UploadPolicy.BackoffPolicy.LINEAR)
+            policy.backoffMillis * retryCount
+        else if (policy.backoffPolicy == UploadPolicy.BackoffPolicy.EXPONENTIAL && retryCount > 0)
+            policy.backoffMillis * 2.0.pow(retryCount - 1).toLong()
+        else 0L
 }

--- a/imagekit/src/main/java/com/imagekit/android/entity/UploadPolicy.kt
+++ b/imagekit/src/main/java/com/imagekit/android/entity/UploadPolicy.kt
@@ -1,4 +1,4 @@
-package com.imagekit.android
+package com.imagekit.android.entity
 
 class UploadPolicy private constructor(
     val networkType: NetworkType,
@@ -77,18 +77,9 @@ class UploadPolicy private constructor(
             .requiresBatteryCharging(false)
             .maxRetries(DEFAULT_MAX_ERROR_RETRIES)
             .backoffCriteria(
-                backoffMillis = UploadPolicy.DEFAULT_BACKOFF_MILLIS,
-                backoffPolicy = UploadPolicy.DEFAULT_BACKOFF_POLICY
+                backoffMillis = DEFAULT_BACKOFF_MILLIS,
+                backoffPolicy = DEFAULT_BACKOFF_POLICY
             )
             .build()
-    }
-
-    fun newBuilder(): Builder {
-        return Builder()
-            .requiresBatteryCharging(requiresCharging)
-            .requiresDeviceIdle(requiresIdle)
-            .backoffCriteria(backoffMillis, backoffPolicy)
-            .maxRetries(maxErrorRetries)
-            .requireNetworkType(networkType)
     }
 }

--- a/imagekit/src/main/java/com/imagekit/android/entity/UploadPolicy.kt
+++ b/imagekit/src/main/java/com/imagekit/android/entity/UploadPolicy.kt
@@ -43,12 +43,13 @@ class UploadPolicy private constructor(
         }
 
         fun maxRetries(maxRetries: Int): Builder {
-            require(maxRetries >= 0) { "maxRetries cannot be negative." }
+            require(maxRetries >= 0) { "maxRetries cannot be a negative integer" }
             this.maxRetries = maxRetries
             return this
         }
 
         fun backoffCriteria(backoffMillis: Long, backoffPolicy: BackoffPolicy): Builder {
+            require(backoffMillis >= 0) { "backoffMillis cannot be a negative integer" }
             this.backoffMillis = backoffMillis
             this.backoffPolicy = backoffPolicy
             return this
@@ -68,7 +69,7 @@ class UploadPolicy private constructor(
 
     companion object {
         private const val DEFAULT_MAX_ERROR_RETRIES = 5
-        private const val DEFAULT_BACKOFF_MILLIS = 100_000L
+        private const val DEFAULT_BACKOFF_MILLIS = 1000L
         private val DEFAULT_BACKOFF_POLICY = BackoffPolicy.LINEAR
 
         fun defaultPolicy(): UploadPolicy = Builder()

--- a/sample/src/main/java/com/imagekit/android/sample/MainActivity.kt
+++ b/sample/src/main/java/com/imagekit/android/sample/MainActivity.kt
@@ -14,10 +14,10 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         ImageKit.init(
             context = applicationContext,
-            publicKey = "YOUR_PUBLIC_KEY",
-            urlEndpoint = "https://ik.imagekit.io/YOUR_IMAGEKIT_ID",
+            publicKey = "public_5P5QM23aRv9XkOcfJO1okZ0DzOw=",
+            urlEndpoint = "https://ik.imagekit.io/tqhfz73me",
             transformationPosition = TransformationPosition.PATH,
-            authenticationEndpoint = "YOUR_AUTHENTICATION_ENDPOINT"
+            authenticationEndpoint = "https://bd1e-2401-4900-1c54-e034-90c7-c25b-fbd1-1769.ngrok-free.app/"
         )
 
         btUploadImage.setOnClickListener {

--- a/sample/src/main/java/com/imagekit/android/sample/MainActivity.kt
+++ b/sample/src/main/java/com/imagekit/android/sample/MainActivity.kt
@@ -17,7 +17,7 @@ class MainActivity : AppCompatActivity() {
             publicKey = "public_5P5QM23aRv9XkOcfJO1okZ0DzOw=",
             urlEndpoint = "https://ik.imagekit.io/tqhfz73me",
             transformationPosition = TransformationPosition.PATH,
-            authenticationEndpoint = "https://bd1e-2401-4900-1c54-e034-90c7-c25b-fbd1-1769.ngrok-free.app/"
+            authenticationEndpoint = "https://027e-119-82-70-86.ngrok-free.app/"
         )
 
         btUploadImage.setOnClickListener {

--- a/sample/src/main/java/com/imagekit/android/sample/UploadImageActivity.kt
+++ b/sample/src/main/java/com/imagekit/android/sample/UploadImageActivity.kt
@@ -64,7 +64,7 @@ class UploadImageActivity : AppCompatActivity(), ImageKitCallback, View.OnClickL
                 useUniqueFilename = true,
                 tags = arrayOf("nice", "copy", "books"),
                 folder = "/dummy/folder/",
-                uploadPolicy = UploadPolicy.Builder().maxRetries(5).backoffCriteria(
+                policy = UploadPolicy.Builder().maxRetries(5).backoffCriteria(
                     backoffMillis = 100L,
                     backoffPolicy = UploadPolicy.BackoffPolicy.EXPONENTIAL
                 ).build(),
@@ -85,7 +85,7 @@ class UploadImageActivity : AppCompatActivity(), ImageKitCallback, View.OnClickL
             fileName = filename,
             useUniqueFilename = true,
             tags = arrayOf("nice", "copy", "books"),
-            uploadPolicy = UploadPolicy.Builder().requiresBatteryCharging(false).build(),
+            policy = UploadPolicy.Builder().requiresBatteryCharging(false).build(),
             folder = "/dummy/folder/",
             imageKitCallback = this
         )

--- a/sample/src/main/java/com/imagekit/android/sample/UploadImageActivity.kt
+++ b/sample/src/main/java/com/imagekit/android/sample/UploadImageActivity.kt
@@ -3,10 +3,8 @@ package com.imagekit.android.sample
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
-import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.os.BatteryManager
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -14,7 +12,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.imagekit.android.ImageKit
 import com.imagekit.android.ImageKitCallback
-import com.imagekit.android.UploadPolicy
+import com.imagekit.android.entity.UploadPolicy
 import com.imagekit.android.entity.UploadError
 import com.imagekit.android.entity.UploadResponse
 import kotlinx.android.synthetic.main.activity_upload_image.*

--- a/sample/src/main/java/com/imagekit/android/sample/UploadImageActivity.kt
+++ b/sample/src/main/java/com/imagekit/android/sample/UploadImageActivity.kt
@@ -3,8 +3,10 @@ package com.imagekit.android.sample
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.os.BatteryManager
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -12,6 +14,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.imagekit.android.ImageKit
 import com.imagekit.android.ImageKitCallback
+import com.imagekit.android.UploadPolicy
 import com.imagekit.android.entity.UploadError
 import com.imagekit.android.entity.UploadResponse
 import kotlinx.android.synthetic.main.activity_upload_image.*
@@ -55,6 +58,7 @@ class UploadImageActivity : AppCompatActivity(), ImageKitCallback, View.OnClickL
                 .setCancelable(false)
                 .show()
 
+
             val filename = "icLauncher.png"
             ImageKit.getInstance().uploader().upload(
                 file = bitmap!!,
@@ -62,6 +66,8 @@ class UploadImageActivity : AppCompatActivity(), ImageKitCallback, View.OnClickL
                 useUniqueFilename = true,
                 tags = arrayOf("nice", "copy", "books"),
                 folder = "/dummy/folder/",
+                uploadPolicy = UploadPolicy.Builder()
+                    .requiresDeviceIdle(false).build(),
                 imageKitCallback = this
             )
         }
@@ -79,6 +85,7 @@ class UploadImageActivity : AppCompatActivity(), ImageKitCallback, View.OnClickL
             fileName = filename,
             useUniqueFilename = true,
             tags = arrayOf("nice", "copy", "books"),
+            uploadPolicy = UploadPolicy.Builder().requiresBatteryCharging(false).build(),
             folder = "/dummy/folder/",
             imageKitCallback = this
         )

--- a/sample/src/main/java/com/imagekit/android/sample/UploadImageActivity.kt
+++ b/sample/src/main/java/com/imagekit/android/sample/UploadImageActivity.kt
@@ -66,8 +66,10 @@ class UploadImageActivity : AppCompatActivity(), ImageKitCallback, View.OnClickL
                 useUniqueFilename = true,
                 tags = arrayOf("nice", "copy", "books"),
                 folder = "/dummy/folder/",
-                uploadPolicy = UploadPolicy.Builder()
-                    .requiresDeviceIdle(false).build(),
+                uploadPolicy = UploadPolicy.Builder().maxRetries(5).backoffCriteria(
+                    backoffMillis = 100L,
+                    backoffPolicy = UploadPolicy.BackoffPolicy.EXPONENTIAL
+                ).build(),
                 imageKitCallback = this
             )
         }


### PR DESCRIPTION
- Create the upload policy to define constraints which must be validated in order to initiate an upload request. It also sets the parameters for the retry mechanism of uploader method.
- Add the parameter to ImageKit init method to set the default upload policy for all the upload request
- Add the parameter to upload method to set the custom upload policy to override the default policy for a particular upload request.