### PR TITLE
Adaptive streaming URL for video

### DIFF
--- a/imagekit/src/main/java/com/imagekit/android/entity/StreamingFormat.kt
+++ b/imagekit/src/main/java/com/imagekit/android/entity/StreamingFormat.kt
@@ -1,0 +1,6 @@
+package com.imagekit.android.entity
+
+enum class StreamingFormat(val extension: String) {
+    HLS("m3u8"),
+    DASH("mpd")
+}

--- a/imagekit/src/main/java/com/imagekit/android/util/TransformationMapping.kt
+++ b/imagekit/src/main/java/com/imagekit/android/util/TransformationMapping.kt
@@ -56,4 +56,5 @@ internal object TransformationMapping {
     const val effectGray = "e-grayscale"
     const val original = "orig"
     const val transformationStep = ":"
+    const val streamingResolution="sr"
 }


### PR DESCRIPTION
- Implement URL constructor method to set streaming format and parameter to set the list of available streaming resolutions for generating manifest URLs for adaptive video streaming.
- Supported formats are HLS and DASH.
- Supported resolutions are set as a list of integers.