### PR TITLE
Responsive image loading

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 03 17:56:32 IST 2019
+#Thu Jun 08 16:25:53 IST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/imagekit/src/main/java/com/imagekit/android/ImagekitUrlConstructor.kt
+++ b/imagekit/src/main/java/com/imagekit/android/ImagekitUrlConstructor.kt
@@ -972,6 +972,12 @@ class ImagekitUrlConstructor constructor(
         return this
     }
 
+    /**
+     * Set the prarameters to fetch the video in an adaptive streaming format.
+     * @param format The desired streaming format to be fetched (HLS or DASH).
+     * @param resolutions The list of video resolutions to be made available to choose from during video streaming.
+     * @return the current ImagekitUrlConstructor object.
+     */
     fun setAdaptiveStreaming(
         format: StreamingFormat,
         resolutions: List<Int>

--- a/sample/src/main/java/com/imagekit/android/sample/FetchImageActivity.kt
+++ b/sample/src/main/java/com/imagekit/android/sample/FetchImageActivity.kt
@@ -84,7 +84,12 @@ class FetchImageActivity : AppCompatActivity(), View.OnClickListener {
                         .width(400)
                         .height(300)
                         .chainTransformation()
-                        .rotation(Rotation.VALUE_90)
+                        .setResponsive(
+                            view = ivImage,
+                            minSize = 200,
+                            maxSize = 1600,
+                            step = 100
+                        )
                         .create()
                 }
                 else ->


### PR DESCRIPTION
- Add the method to URL constructor with input an Android view with minimum & maximum dimension sizes, crop and focus modes to create a URL for an image responsive to the target view & device.
- The method sets the height and width of image based on the dimensions of the target view, falling back to screen width & height if the view's dimensions are not set.
- The DPR of image is set to be match the pixel density of the device screen.